### PR TITLE
chore: Update action versions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: ./prepare-node-repo
       - run: npm run lint -- --no-write

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./npm/install
         with:
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./npm/install
         with:
@@ -37,7 +37,7 @@ jobs:
   prepare-node-repo-cypress:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./prepare-node-repo
         with:
@@ -50,7 +50,7 @@ jobs:
   prepare-node-repo-cypress-yarn:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ./prepare-node-repo
         with:

--- a/npm/install/action.yml
+++ b/npm/install/action.yml
@@ -28,7 +28,7 @@ runs:
 
     - name: "Restoring cache"
       id: cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           ${{ steps.vars.outputs.npm-cache-dir }}

--- a/prepare-node-repo/action.yml
+++ b/prepare-node-repo/action.yml
@@ -21,17 +21,17 @@ runs:
   using: "composite"
   steps:
     - name: "Stopping previous runs"
-      uses: styfle/cancel-workflow-action@0.9.1
+      uses: styfle/cancel-workflow-action@0.11.0
 
     - name: "Disable automatic line-end conversion"
       shell: bash
       run: git config --global core.autocrlf false
 
     - name: "Checking out the repository repository"
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: "Setting up Node"
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: ${{ inputs.node-version }}
         cache: ${{ inputs.package-manager }}


### PR DESCRIPTION
[Node.js v12](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) and [save-state/set-output](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) will be deprecated in the future. Updating external actions with the latest versions to prepare for that.