### PR TITLE
refactor: Replace set-output with GITHUB_OUTPUT env file

### DIFF
--- a/npm/install/action.yml
+++ b/npm/install/action.yml
@@ -21,10 +21,10 @@ runs:
       shell: bash
       working-directory: ${{ inputs.working-directory }}
       run: |
-        echo "::set-output name=npm-cache-dir::$(npm config get cache || "")";
-        echo "::set-output name=yarn-cache-dir::$(yarn cache dir || "")";
-        echo "::set-output name=restore-key-prefix::${{ inputs.cache-key }}${{ runner.os }}-";
-        echo "::set-output name=lockfile-hash::${{ hashFiles(format('{0}/yarn.lock', inputs.working-directory), format('{0}/pnpm-lock.yaml', inputs.working-directory), format('{0}/package-lock.json', inputs.working-directory)) }}";
+        echo "npm-cache-dir=$(npm config get cache || "")" >> $GITHUB_OUTPUT
+        echo "yarn-cache-dir=$(yarn cache dir || "")" >> $GITHUB_OUTPUT
+        echo "restore-key-prefix=${{ inputs.cache-key }}${{ runner.os }}-" >> $GITHUB_OUTPUT
+        echo "lockfile-hash=${{ hashFiles(format('{0}/yarn.lock', inputs.working-directory), format('{0}/pnpm-lock.yaml', inputs.working-directory), format('{0}/package-lock.json', inputs.working-directory)) }}" >> $GITHUB_OUTPUT
 
     - name: "Restoring cache"
       id: cache


### PR DESCRIPTION
Replacing deprecated methods of setting outputs with [new one](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).