### PR TITLE
Avoid npx installation prompt with env variable instead of --yes argument

### DIFF
--- a/npm/install/action.yml
+++ b/npm/install/action.yml
@@ -40,11 +40,13 @@ runs:
     - name: "Installing dependencies"
       shell: bash
       working-directory: ${{ inputs.working-directory }}
+      env:
+        npm_config_yes: "true"
       run: |
         if [[ "${{ steps.cache.outputs.cache-hit }}" == "true" ]]; then
           echo 'Cache is valid, skipping installation';
         else
           echo "::group::Installing dependencies";
-          npx --yes @antfu/ni --frozen
+          npx @antfu/ni --force
           echo "::endgroup::";
         fi;


### PR DESCRIPTION
Using `npm_config_yes` environment variable instead of `--yes` argument as [explained here](https://github.com/npm/cli/issues/2226). Need to test if env variable actually passed to npx in GitHub action